### PR TITLE
rename print options in export_options.cc

### DIFF
--- a/psi4/src/export_options.cc
+++ b/psi4/src/export_options.cc
@@ -57,6 +57,6 @@ void export_options(py::module& m) {
         .def("set_current_module", &Options::set_current_module, "sets *arg0* (all CAPS) as current module")
         .def("get_current_module", &Options::get_current_module, "gets current module")
         .def("validate_options", &Options::validate_options, "validate options for *arg0* module")
-        .def("print", &Options::print, "print options")
-        .def("print_globals", &Options::print_globals, "print global options");
+        .def("print_module_options", &Options::print, "print global and local options prepared for current module")
+        .def("print_global_options", &Options::print_globals, "print the global, cross-module options");
 }


### PR DESCRIPTION
## Description
`print` might look too appealing and comprehensive to a user who doesn't understand the multi-leveled-ness of `psi4.core.Options`. See if you like these slight changes.

## Status
- [x] Ready for review
- [x] Ready for merge
